### PR TITLE
fixed travis ci xvfb start issue for default dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,9 @@ notifications:
 cache:
   directories:
     - node_modules
+services:
+  - xvfb
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - "sleep 3"
   - "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter"
   - "chmod +x ./cc-test-reporter"
   - "./cc-test-reporter before-build"


### PR DESCRIPTION
Due to breaking change for default dist (xenial)

https://benlimmer.com/2019/01/14/travis-ci-xvfb/
https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services-xvfb